### PR TITLE
feat: Unload model on background and restore history

### DIFF
--- a/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/LlamaApi.kt
+++ b/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/LlamaApi.kt
@@ -30,5 +30,6 @@ object LlamaApi {
     external fun init(modelPath: String): Long
     external fun free(sessionPtr: Long)
     external fun predict(sessionPtr: Long, prompt: String, callback: PredictCallback)
+    external fun restoreHistory(sessionPtr: Long, messages: Array<Any>)
 
 }

--- a/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/MainActivity.kt
+++ b/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/MainActivity.kt
@@ -8,13 +8,23 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.nikolaspaci.app.llamallmlocal.ui.AppNavigation
 import com.nikolaspaci.app.llamallmlocal.ui.theme.LlamaLLmLocalTheme
 import com.nikolaspaci.app.llamallmlocal.viewmodel.ViewModelFactory
  
+import com.nikolaspaci.app.llamallmlocal.jni.LlamaJniService
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStop(owner: LifecycleOwner) {
+                LlamaJniService.unloadModel()
+            }
+        })
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             LlamaLLmLocalTheme {

--- a/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/jni/LlamaJniService.kt
+++ b/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/jni/LlamaJniService.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 
-class LlamaJniService {
+object LlamaJniService {
 
     private var sessionPtr: Long = 0
 
@@ -57,6 +57,12 @@ class LlamaJniService {
         if (sessionPtr != 0L) {
             LlamaApi.free(sessionPtr)
             sessionPtr = 0
+        }
+    }
+
+    fun restoreHistory(messages: Array<Any>) {
+        if (sessionPtr != 0L) {
+            LlamaApi.restoreHistory(sessionPtr, messages)
         }
     }
 }

--- a/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/ui/NavGraph.kt
+++ b/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/ui/NavGraph.kt
@@ -105,11 +105,9 @@ fun AppNavigation(factory: ViewModelFactory) {
                 val context = LocalContext.current
                 val db = AppDatabase.getDatabase(context)
                 val chatRepository = ChatRepository(db.chatDao())
-                val llamaJniService = LlamaJniService()
 
                 val chatViewModelFactory = ChatViewModelFactory(
                     chatRepository,
-                    llamaJniService,
                     conversationId
                 )
 

--- a/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/viewmodel/ChatViewModel.kt
+++ b/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/viewmodel/ChatViewModel.kt
@@ -78,6 +78,11 @@ class ChatViewModel(
                     _isModelReady.value = false
                     withContext(Dispatchers.IO) {
                         llamaJniService.loadModel(modelPath)
+                        (_uiState.value as? ChatUiState.Success)?.let {
+                            if (it.messages.isNotEmpty()) {
+                                llamaJniService.restoreHistory(it.messages.toTypedArray())
+                            }
+                        }
                     }
                     _isModelReady.value = true
 

--- a/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/viewmodel/ChatViewModelFactory.kt
+++ b/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/viewmodel/ChatViewModelFactory.kt
@@ -7,14 +7,13 @@ import com.nikolaspaci.app.llamallmlocal.jni.LlamaJniService
 
 class ChatViewModelFactory(
     private val chatRepository: ChatRepository,
-    private val llamaJniService: LlamaJniService,
     private val conversationId: Long
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(ChatViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return ChatViewModel(chatRepository, llamaJniService, conversationId) as T
+            return ChatViewModel(chatRepository, LlamaJniService, conversationId) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/viewmodel/ViewModelFactory.kt
+++ b/LlamaLlmLocal/app/src/main/java/com/nikolaspaci/app/llamallmlocal/viewmodel/ViewModelFactory.kt
@@ -13,7 +13,6 @@ class ViewModelFactory(private val context: Context) : ViewModelProvider.Factory
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         val db = AppDatabase.getDatabase(context)
         val chatRepository = ChatRepository(db.chatDao())
-        val llamaJniService = LlamaJniService()
         val sharedPreferences = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
 
 
@@ -22,7 +21,7 @@ class ViewModelFactory(private val context: Context) : ViewModelProvider.Factory
                 HistoryViewModel(chatRepository, sharedPreferences) as T
             }
             modelClass.isAssignableFrom(SettingsViewModel::class.java) -> {
-                SettingsViewModel(context, sharedPreferences, llamaJniService) as T
+                SettingsViewModel(context, sharedPreferences, LlamaJniService) as T
             }
             modelClass.isAssignableFrom(HomeViewModel::class.java) -> {
                 HomeViewModel(chatRepository) as T

--- a/llamaCpp/CmakeLists.txt
+++ b/llamaCpp/CmakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCE_FILES_LIST
     ${PROJECT_SOURCE_DIR}/src/JNIMethods/InitJni.cpp
     ${PROJECT_SOURCE_DIR}/src/JNIMethods/PredictJni.cpp
     ${PROJECT_SOURCE_DIR}/src/JNIMethods/FreeJni.cpp
+    ${PROJECT_SOURCE_DIR}/src/JNIMethods/RestoreHistoryJni.cpp
 )
 
 if(ANDROID)

--- a/llamaCpp/include/JNIMethods/RestoreHistoryJni.hpp
+++ b/llamaCpp/include/JNIMethods/RestoreHistoryJni.hpp
@@ -1,0 +1,14 @@
+#ifndef RESTOREHISTORYJNI_HPP
+#define RESTOREHISTORYJNI_HPP
+
+#include "jni.h"
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_nikolaspaci_app_llamallmlocal_LlamaApi_restoreHistory(
+    JNIEnv *env,
+    jobject /* this */,
+    jlong session_ptr,
+    jobjectArray messages
+);
+
+#endif // RESTOREHISTORYJNI_HPP

--- a/llamaCpp/src/JNIMethods/RestoreHistoryJni.cpp
+++ b/llamaCpp/src/JNIMethods/RestoreHistoryJni.cpp
@@ -1,0 +1,46 @@
+#include "JNIMethods/RestoreHistoryJni.hpp"
+#include "session/LlamaSession.hpp"
+#include "llama-cpp.h"
+#include <string>
+#include <vector>
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_nikolaspaci_app_llamallmlocal_LlamaApi_restoreHistory(
+    JNIEnv *env,
+    jobject /* this */,
+    jlong session_ptr,
+    jobjectArray messages
+) {
+    LlamaSession* session = reinterpret_cast<LlamaSession*>(session_ptr);
+    if (!session) {
+        return;
+    }
+
+    session->messages.clear();
+
+    jsize message_count = env->GetArrayLength(messages);
+    for (jsize i = 0; i < message_count; ++i) {
+        jobject chat_message_obj = env->GetObjectArrayElement(messages, i);
+        jclass chat_message_class = env->GetObjectClass(chat_message_obj);
+
+        jfieldID sender_field = env->GetFieldID(chat_message_class, "sender", "Lcom/nikolaspaci/app/llamallmlocal/data/database/Sender;");
+        jobject sender_obj = env->GetObjectField(chat_message_obj, sender_field);
+        jclass sender_class = env->GetObjectClass(sender_obj);
+        jmethodID get_name_method = env->GetMethodID(sender_class, "name", "()Ljava/lang/String;");
+        jstring sender_name_j = (jstring)env->CallObjectMethod(sender_obj, get_name_method);
+        const char* sender_name_c = env->GetStringUTFChars(sender_name_j, nullptr);
+        std::string role = (strcmp(sender_name_c, "USER") == 0) ? "user" : "assistant";
+        env->ReleaseStringUTFChars(sender_name_j, sender_name_c);
+
+        jfieldID message_field = env->GetFieldID(chat_message_class, "message", "Ljava/lang/String;");
+        jstring message_j = (jstring)env->GetObjectField(chat_message_obj, message_field);
+        const char* message_c = env->GetStringUTFChars(message_j, nullptr);
+
+        session->messages.push_back({strdup(role.c_str()), strdup(message_c)});
+
+        env->ReleaseStringUTFChars(message_j, message_c);
+        env->DeleteLocalRef(chat_message_obj);
+        env->DeleteLocalRef(sender_obj);
+        env->DeleteLocalRef(sender_name_j);
+    }
+}


### PR DESCRIPTION
This commit implements a more advanced solution to the chat history problem. The Llama model is now unloaded from memory when the app goes to the background, and the history is restored from the database when a conversation is reopened.

This approach provides a good balance between performance and user experience, as it frees up memory when the app is not in use, while still preserving the conversation history.

The changes include:

1.  A new JNI method `restoreHistory` to load the chat history from the database into the Llama model.
2.  Updates to `ChatViewModel` to call the new `restoreHistory` method when a conversation is opened.
3.  An app lifecycle observer in `MainActivity` to detect when the app goes to the background and to call `unloadModel`.

Note: I was unable to run the tests in the provided environment due to issues with the Android SDK configuration. The code has been implemented as per the plan and my understanding of the codebase.